### PR TITLE
Fix `DBT_PROFILES_DIR` for Users not part of `gitpod-samples` Org

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,7 +1,11 @@
+# Use Gitpod's latest Python image
 FROM gitpod/workspace-python:latest
 
+# Set the path of dbt's profiles file
 ENV DBT_PROFILES_DIR=./profiles/
 
+# Copy requirements file from host into Container
 COPY requirements.txt /tmp
 
+# Install the requirements
 RUN cd /tmp && pip install -r requirements.txt

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,5 +1,7 @@
 FROM gitpod/workspace-python:latest
 
+ENV DBT_PROFILES_DIR=./profiles/
+
 COPY requirements.txt /tmp
 
 RUN cd /tmp && pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -35,14 +35,6 @@ If all commands run succesfully, you have completed the setup of a working dbt d
 
 Click the above "Open in Gitpod" button to start a new workspace. Once you're ready to push your first code changes, Gitpod will guide you to fork this project so you own it.
 
-Beware that we used Gitpod's [project-specific environment variables](https://www.gitpod.io/docs/configure/projects/environment-variables#project-specific-environment-variables) to store the path to the `.profiles.yml`. For this project to work in a new environment, we recommend you create a [Gitpod project](https://www.gitpod.io/docs/configure/projects) for it and set up the project variable `DBT_PROFILES_DIR` with the value `./profiles/`.
-
-Alternatively, you can also make sure that the path is accessible in each terminal by setting a [terminal-specific Environment variable](https://www.gitpod.io/docs/configure/projects/environment-variables#task-terminal-specific-environment-variables) for each terminal you use, e.g. by running
-```bash title=".gitpod.yml"
-export DBT_PROFILES_DIR=./profiles/
-```
-at the top of each task section in the `.gitpod.yml`.
-
 ### An existing project
 
 To get started with dbt on Gitpod, add a [`.gitpod.yml`](./.gitpod.yml) to any of your existing dbt projects. To learn more, please see the [Getting Started](https://www.gitpod.io/docs/getting-started) documentation.


### PR DESCRIPTION
## Description

When testing, I discovered that Users who are not part of the `gitpod-samples` Org will also not have access to the `DBT_PROFILES_DIR` variable set on project scope. As this repo is going to be used for demo purposes, we must ensure that the path is set for any user. Using Docker's `ENV` command is the most straight-forward way i could find to do so.